### PR TITLE
added security for Role Specific APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,21 @@ STEP-9) test the application
 	
 	iii.now go to any other API, in the 'Header' section, provide the token as : 'Bearer <token>' and hit the request, and you'll be able to access the API
 ```
+`
+<br>
+<br>
+#Role Specific APIs
+STEP-1) Check the DB -> 
+		i. user table -> check if for all the users, passwords are encoded, and know the decoded passwords
+		ii. role table -> check if roles 'ROLE_ADMIN' and 'ROLE_NORMAL' are already created, if not created, then create the roles
+		iii. user_role table -> check if specific roles are assigned to specific users or not, if not then assign
+STEP-2) annotate the class 'SecurityConfig' with @EnableGlobalMethodSecurity(prePostEnabled=true) -> now we can apply security in each method
+STEP-3) go to the specific HTTP method controller for which you want to apply this, annotate the method @Preauthorize("hasRole('<ROLE>')")
+STEP-4) if you want to secure a bunch of APIs with specific URL pattern, then secure them in the SecurityConfig ->
+		code : antMatchers/requestMathers("<URL-pattern>").hasRole('<ROLE>')
+		example: requestMatchers("/users/delete").hasRole('ADMIN')
+STEP-5) if you want to un-secure (publicly accessible) any specific type of Requests, then un-secure them in the SecurityConfig ->
+		code : antMatchers/requestMatchers(HttpMethod.<HTTP-METHOD>).permitAll()
+		example : requestMatchers(HttpMethod.GET).permitAll()
+		
+

--- a/src/main/java/com/bikram/blog/config/SercurityConfig.java
+++ b/src/main/java/com/bikram/blog/config/SercurityConfig.java
@@ -4,9 +4,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -23,6 +25,7 @@ import com.bikram.blog.security.JwtAuthenticationFilter;
 import org.springframework.security.config.annotation.web.configurers.SessionManagementConfigurer;
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true) //now we can apply security in each method
 public class SercurityConfig {
 
 	@Autowired
@@ -41,6 +44,8 @@ public class SercurityConfig {
 		.csrf().disable()
 		.authorizeHttpRequests()
 		.requestMatchers("/auth/login").permitAll() // making 'login' url public
+		.requestMatchers(HttpMethod.GET).permitAll() // making all HTTP GET methods publicly accessible
+		.requestMatchers("/categories/**").hasRole("ADMIN") // only ADMIN can access the category APIs (POST, PUT & DELETE) but GET APIs will be accessible publicly as configuration is already done for all GET end-points such that all the GET end-points are accessible publicly (because In Spring Security, the order of rules matters, and rules are applied in the sequence they are defined) 
 		.anyRequest()
 		.authenticated()
 		.and()

--- a/src/main/java/com/bikram/blog/controllers/UserController.java
+++ b/src/main/java/com/bikram/blog/controllers/UserController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -48,6 +49,7 @@ public class UserController {
 	}
 	
 	// delete user
+	@PreAuthorize("hasRole('ADMIN')")
 	@DeleteMapping("/delete-user/{userId}")
 	public ResponseEntity<ApiResponse> deleteUser(@PathVariable Integer userId){
 		String message = this.userService.deleteUser(userId);


### PR DESCRIPTION
- added security for Role Specific APIs (here I've implemented the security such that only ADMIN can delete users)
- making all GET endpoints publicly accessible
- only ADMIN can access the category APIs (POST, PUT & DELETE) but but GET APIs will be accessible publicly as configuration is already done for all GET end-points such that all the GET end-points are accessible publicly (because In Spring Security, the order of rules matters, and rules are applied in the sequence they are defined)